### PR TITLE
Rework the way types and sources are retrieved.

### DIFF
--- a/app/assets/javascripts/mixingpanel/properties.js.coffee
+++ b/app/assets/javascripts/mixingpanel/properties.js.coffee
@@ -63,12 +63,14 @@ class @MixingpanelProperties
         query_string.split('+')
 
   _getType: ->
-    if @referer == ""
-      "Direct"
+    if @location.query_string.utm_medium is "ppc"
+      "SEM"
     else if @engine?
-      if @location.query_string.utm_campaign? then "SEM" else "SEO"
-    else
+      "SEO"
+    else if @referer isnt ""
       "Referral"
+    else
+      "Direct"
 
   google: ->
     !@host.match(/plus.google\.[a-z]{2,4}/) && @host.match(/google\.[a-z]{2,4}/)

--- a/app/assets/javascripts/mixingpanel/source.js.coffee
+++ b/app/assets/javascripts/mixingpanel/source.js.coffee
@@ -28,16 +28,18 @@ class @MixingpanelSource
     @getValue = callback if typeof callback is "function"
 
   getValue: () ->
-    if @utm.medium? or @utm.campaign?
+    if @utm.medium?
       if @utm.medium is "email"
         @sources.EMAIL
-      else
+      else if @utm.medium is "ppc"
         @sources.SEM
+      else
+        undefined
 
     else if @properties.engine?
       @sources.SEO
 
-    else if @properties.referer != ""
+    else if @properties.referer isnt ""
       if @properties.isSocial()
         @sources.SOCIAL
       else

--- a/lib/mixingpanel/version.rb
+++ b/lib/mixingpanel/version.rb
@@ -1,3 +1,3 @@
 module Mixingpanel
-  VERSION = "0.12.4"
+  VERSION = "0.12.5"
 end

--- a/spec/javascripts/mixingpanel_properties_spec.js.coffee
+++ b/spec/javascripts/mixingpanel_properties_spec.js.coffee
@@ -116,8 +116,8 @@ describe "MixingpanelProperties", ->
       mpp = new MixingpanelProperties(@internal_domain, "http://www.bing.com")
       expect(mpp.type).toEqual("SEO")
 
-    it "should get 'SEM' for a google referrer with utm_campaign param is 'sem'", ->
-      mpp = new MixingpanelProperties(@internal_domain, "https://google.com", "?utm_campaign=sem")
+    it "should get 'SEM' when utm_medium param is 'ppc'", ->
+      mpp = new MixingpanelProperties(@internal_domain, "https://google.com", "?utm_medium=ppc")
       expect(mpp.type).toEqual("SEM")
 
     it "should get 'Referral' for an internal referrer", ->

--- a/spec/javascripts/mixingpanel_source_spec.js.coffee
+++ b/spec/javascripts/mixingpanel_source_spec.js.coffee
@@ -17,14 +17,14 @@ describe "MixingpanelSource", ->
     it "should return Email when the utm_medium is 'email'", ->
       mpp = new MixingpanelProperties("kelisto.es",
                                       "http://kelisto.es/",
-                                      "?utm_source=foo&utm_medium=email&utm_campaign=meh")
+                                      "?utm_source=foo&utm_medium=email&utm_campaign=bar")
       mps = new MixingpanelSource(mpp)
       expect(mps.getValue()).toEqual("Email")
 
-    it "should return SEM when the utm_medium is not 'email'", ->
+    it "should return SEM when the utm_medium is 'ppc'", ->
       mpp = new MixingpanelProperties("kelisto.es",
                                       "http://google.es/",
-                                      "?utm_source=foo&utm_medium=bar&utm_campaign=meh")
+                                      "?utm_source=foo&utm_medium=ppc&utm_campaign=bar")
       mps = new MixingpanelSource(mpp)
       expect(mps.getValue()).toEqual("SEM")
 


### PR DESCRIPTION
Use now 'utm_medium' as base param value for retrieving SEM type/sources.
