### PR TITLE
Pack register in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,7 @@
 will include a bunch of superproperties in addition to 'source' itself. The aim is to debug
 what were the data comming with each first and last superproperty in every moment.
 
+## 0.23.0 (March 20, 2014)
+
+* Pack all superproperties in a object and call mixpanel.register only once
+* Remove some not used debug properties

--- a/README.md
+++ b/README.md
@@ -194,16 +194,9 @@ You can change this expiration days value by
 
 As extra properties for **debug** aim:
 * <strong>first/last_timestamp</strong> set the timestamp in the moment of the tracking.
-* <strong>first/last_location_url</strong> set the location URL in the moment of the tracking.
-* <strong>first/last_location_domain</strong> set the location domain in the moment of the tracking.
-* <strong>first/last_location_path</strong> set the location path in the moment of the tracking.
-* <strong>first/last_referrer_url</strong> set the referrer URL in the moment of the tracking.
-* <strong>first/last_referrer_domain</strong> set the referrer domain in the moment of the tracking.
-* <strong>first/last_referrer_path</strong> set the referrer path in the moment of the tracking.
 * <strong>first/last_type</strong> set the type in the moment of the tracking.
-* <strong>first/last_page_type</strong> set the page type in the moment of the tracking.
-* <strong>first/last_page_name</strong> set the page name in the moment of the tracking.
-* <strong>first/last_search_terms</strong> set the search terms in the moment of the tracking.
+* <strong>first/last_location_url</strong> set the location URL in the moment of the tracking.
+* <strong>first/last_referrer_url</strong> set the referrer URL in the moment of the tracking.
 
 
 ## Running *Jasmine* test suite

--- a/app/assets/javascripts/mixingpanel/source.js.coffee
+++ b/app/assets/javascripts/mixingpanel/source.js.coffee
@@ -60,12 +60,15 @@ class @MixingpanelSource
 
   append: ->
     value = @getValue()
-    @writeReferenceTouch(value)
+    allSources = {}
+    allSources = @getReferenceTouch(value)
     if @registerSource() and value?
-      @writeFirstTouch(value)
-      @writeLastTouch(value)
-      @writeSource(value)
-      value
+      allSources = $.extend(allSources, @getFirstTouch(value)) if @firstTouchIsExpired()
+      allSources = $.extend(allSources, @getLastTouch(value))
+      allSources = $.extend(allSources, @getSource(value))
+
+    mixpanel.register allSources
+    allSources
 
   registerSource: ->
     @utm.medium? or !@properties.isInternal()
@@ -77,40 +80,31 @@ class @MixingpanelSource
 
     isNaN(first_touch_ms) or ((first_touch_ms + exp_days_ms) < current_time_ms)
 
-  writeReferenceTouch: (value)->
-    mixpanel.register @propertiesFor(value, "ref_touch")
+  getReferenceTouch: (value)->
+    @propertiesFor(value, "ref_touch")
 
-  writeFirstTouch: (value)->
-    mixpanel.register @propertiesFor(value, "first_touch") if @firstTouchIsExpired()
+  getFirstTouch: (value)->
+    @propertiesFor(value, "first_touch")
 
-  writeLastTouch: (value)->
-    mixpanel.register @propertiesFor(value, "last_touch")
+  getLastTouch: (value)->
+    @propertiesFor(value, "last_touch")
 
-  writeSource: (value)->
-    source = mixpanel.get_property(@sourceProperty)
-    if source
-      if source[source.length-1] != value
-        mixpanel.get_property(@sourceProperty).push(value)
+  getSource: (value)->
+    sources = mixpanel.get_property(@sourceProperty)
+    if sources?
+      sources.push(value) if sources[sources.length-1] isnt value
     else
-      prop = {}
-      prop[@sourceProperty] = [value]
-      mixpanel.register(prop)
+      sources = [value]
+
+    prop = {}
+    prop[@sourceProperty] = sources
+    prop
 
   propertiesFor: (source, base_name = "last_touch")->
     props = {}
-    props[base_name+"_source"] = source
-    props[base_name+"_timestamp"] = new Date()
-    if @properties.location.href?
-      props[base_name+"_location_url"] = @properties.location.href
-      props[base_name+"_location_domain"] = @properties.location.href.match(/^(https*:\/\/.+)(\/.*)/)[1]
-      props[base_name+"_location_path"] = @properties.location.href.match(/^(https*:\/\/.+)(\/.*)/)[2]
-    if @properties.uri.href?
-      props[base_name+"_referrer_url"] = @properties.uri.href
-      props[base_name+"_referrer_domain"] = @properties.uri.href.match(/^(https*:\/\/.+)(\/.*)/)[1]
-      props[base_name+"_referrer_path"] = @properties.uri.href.match(/^(https*:\/\/.+)(\/.*)/)[2]
-    props[base_name+"_type"] = @properties.type
-    props[base_name+"_page_type"] = @properties.pageType()
-    props[base_name+"_page_name"] = @properties.pageName()
-    props[base_name+"_seach_terms"] = @properties.search_terms
-
+    props[base_name+"_source"]       = source
+    props[base_name+"_timestamp"]    = new Date()
+    props[base_name+"_type"]         = @properties.type
+    props[base_name+"_location_url"] = @properties.location.href if @properties.uri?
+    props[base_name+"_referrer_url"] = @properties.uri.href if @properties.uri?
     props

--- a/lib/mixingpanel/version.rb
+++ b/lib/mixingpanel/version.rb
@@ -1,3 +1,3 @@
 module Mixingpanel
-  VERSION = "0.22.4"
+  VERSION = "0.23.0"
 end

--- a/spec/javascripts/mixingpanel_source_spec.js.coffee
+++ b/spec/javascripts/mixingpanel_source_spec.js.coffee
@@ -62,48 +62,45 @@ describe "MixingpanelSource", ->
       mpp = new MixingpanelProperties("kelisto.es", "http://meh.kelisto.es")
       mps = new MixingpanelSource(mpp, append: false)
 
-      spyOn(mps, "writeReferenceTouch")
-      spyOn(mixpanel, "register")
+      spyOn(mps, "getFirstTouch")
+      spyOn(mps, "getLastTouch")
+      spyOn(mps, "getSource")
 
       mps.append()
 
-      expect(mixpanel.register).not.toHaveBeenCalled()
+      expect(mps.getFirstTouch).not.toHaveBeenCalled()
+      expect(mps.getLastTouch).not.toHaveBeenCalled()
+      expect(mps.getSource).not.toHaveBeenCalled()
 
     it "should set the first touch source property", ->
       mpp = new MixingpanelProperties("kelisto.es", "http://www.google.com")
       mps = new MixingpanelSource(mpp, append: false)
 
-      spyOn(mps, "writeSource")
-      spyOn(mps, "writeLastTouch")
+      spyOn(mps, "getFirstTouch")
       spyOn(mps, "firstTouchIsExpired").and.returnValue(true)
-      spyOn(mixpanel, "register")
 
       mps.append()
 
-      expect(mixpanel.register).toHaveBeenCalled()
+      expect(mps.getFirstTouch).toHaveBeenCalled()
 
     it "shouldn't set the first touch property if it is already setted", ->
       mpp = new MixingpanelProperties("kelisto.es", "http://www.google.com")
       mps = new MixingpanelSource(mpp, append: false)
 
-      spyOn(mps, "writeSource")
-      spyOn(mps, "writeReferenceTouch")
-      spyOn(mps, "writeLastTouch")
-      spyOn(mixpanel, "register")
+      spyOn(mps, "getFirstTouch")
       spyOn(mps, "firstTouchIsExpired").and.returnValue(false)
 
       mps.append()
 
-      expect(mixpanel.register).not.toHaveBeenCalled()
+      expect(mps.getFirstTouch).not.toHaveBeenCalled()
 
     it "should set the last touch source property", ->
       mpp = new MixingpanelProperties("kelisto.es", "http://www.facebook.com")
       mps = new MixingpanelSource(mpp, append: false)
 
-      spyOn(mps, "writeSource")
-      spyOn(mps, "writeFirstTouch")
       spyOn(mixpanel, "register")
 
+      debugger
       mps.append()
 
       source = mixpanel.register.calls.mostRecent().args[0].last_touch_source
@@ -113,41 +110,36 @@ describe "MixingpanelSource", ->
       mpp = new MixingpanelProperties("kelisto.es", "http://www.facebook.com")
       mps = new MixingpanelSource(mpp, append: false)
 
-      spyOn(mps, "writeFirstTouch")
-      spyOn(mps, "writeLastTouch")
       spyOn(mixpanel, "register")
       spyOn(mixpanel, "get_property").and.returnValue(undefined)
 
       mps.append()
 
-      prop = {}
-      prop[mps.sourceProperty] = ['Social']
-      expect(mixpanel.register).toHaveBeenCalledWith(prop)
+      source = mixpanel.register.calls.mostRecent().args[0].source
+      expect(source).toEqual(["Social"])
 
     it "should append value to source property if the last value isn't the same", ->
       mpp = new MixingpanelProperties("kelisto.es", "http://www.facebook.com")
       mps = new MixingpanelSource(mpp, append: false)
       array = ['Direct']
 
-      spyOn(mps, "writeFirstTouch")
-      spyOn(mps, "writeLastTouch")
       spyOn(mixpanel, "get_property").and.returnValue(array)
-      spyOn(array, "push")
+      spyOn(mixpanel, "register")
 
       mps.append()
 
-      expect(array.push).toHaveBeenCalledWith('Social')
+      source = mixpanel.register.calls.mostRecent().args[0].source
+      expect(source).toEqual(['Direct','Social'])
 
     it "shouldn't add value to source property if the last value is the same", ->
       mpp = new MixingpanelProperties("kelisto.es", "http://www.facebook.com")
       mps = new MixingpanelSource(mpp, append: false)
       array = ['Social']
 
-      spyOn(mps, "writeFirstTouch")
-      spyOn(mps, "writeLastTouch")
       spyOn(mixpanel, "get_property").and.returnValue(array)
-      spyOn(array, "push")
+      spyOn(mixpanel, "register")
 
       mps.append()
 
-      expect(array.push).not.toHaveBeenCalledWith('Social')
+      source = mixpanel.register.calls.mostRecent().args[0].source
+      expect(source).toEqual(['Social'])


### PR DESCRIPTION
- Pack all sources (ref,first,last and source) in a single object to call `mixpanel.register`only once.
- Remove properties not used as _page_type_, _page_name_, _search_terms_, _location_domain_, _location_path_, _referrer_domain_ and _referrer_path_
