### PR TITLE
Options now can ask for external domains exceptions

### DIFF
--- a/app/assets/javascripts/mixingpanel/parameterizer.js.coffee
+++ b/app/assets/javascripts/mixingpanel/parameterizer.js.coffee
@@ -1,9 +1,11 @@
 class @MixingpanelParameterizer
-  constructor: (@properties, @whitelist = []) ->
+  constructor: (@properties) ->
     @cookies    = new MixingpanelCookies()
+    @whitelist  = mixingpanel_options.tracking_params
     @cookieName = 'mp_tracking_params'
 
-    @delete() and @write() unless @properties.isInternal()
+    if not @properties.isInternal() or @properties.isExternalDomainException()
+      @delete() and @write()
 
   write: ->
     opts =

--- a/app/assets/javascripts/mixingpanel/properties.js.coffee
+++ b/app/assets/javascripts/mixingpanel/properties.js.coffee
@@ -1,5 +1,8 @@
 class @MixingpanelProperties
-  constructor: (@internal_domain = window.location.host, url, search) ->
+  constructor: (internal_domain, url, search) ->
+    @internal_domain = (internal_domain or
+                        mixingpanel_options.internal_domain or
+                        window.location.host)
     @location = @_getLocation(search)
     @referer = if url? then url else document.referrer
     @uri = @_getUri()
@@ -87,6 +90,15 @@ class @MixingpanelProperties
     domain = @internal_domain.split('.').slice(-2).join('.')
     if @host.match(domain) then true else false
 
+  # There are some exception on domains that we'll consider as external anyway
+  isExternalDomainException: ->
+    return false unless @uri.hostname?
+
+    for referringDomain in mixingpanel_options.external_domains
+      regexp = new RegExp ".*#{referringDomain}"
+      return true if @uri.hostname.match(regexp)
+    false
+
   isSocial: ->
     (@host.match(/busuu\.com$/) or
      @host.match(/delicious\.com$/) or
@@ -105,6 +117,7 @@ class @MixingpanelProperties
      @host.match(/t\.co$/) or
      @host.match(/xing\.com$/))?
 
+  # DEPRECATION WARNING: this function are not used for a real purpose
   pageName: ->
     if (@location.pathname == '/')
       "Home"
@@ -127,6 +140,7 @@ class @MixingpanelProperties
     else
       "unknown"
 
+  # DEPRECATION WARNING: this function are not used for a real purpose
   pageType: ->
     return "Default" unless $('body').data('mp')?
     $("body").data('mp')["Page type"] or "Default"

--- a/app/assets/javascripts/mixingpanel/session.js.coffee
+++ b/app/assets/javascripts/mixingpanel/session.js.coffee
@@ -1,5 +1,5 @@
 class @MixingpanelSession
-  constructor: (@properties, options = {}) ->
+  constructor: (@properties) ->
     @_parseSession()
     if @mp_session.start
         mixpanel.register(@_sessionRegister())

--- a/app/assets/javascripts/mixingpanel/source.js.coffee
+++ b/app/assets/javascripts/mixingpanel/source.js.coffee
@@ -1,8 +1,7 @@
 class @MixingpanelSource
-  constructor: (@properties, options = {}) ->
+  constructor: (@properties) ->
     @cookies = new MixingpanelCookies()
-    @referringDomainExceptions = options.referringDomainExceptions or []
-    @expirationDays = options.firstTouchExpirationDays or 30
+    @expirationDays = mixingpanel_options.source.firstTouchExpirationDays or 30
     @firstSourceProperty = "first_touch_source"
     @firstTimestampProperty = "first_touch_timestamp"
     @lastSourceProperty = "last_touch_source"
@@ -15,8 +14,8 @@ class @MixingpanelSource
       SOCIAL: "Social"
       REFERRAL: "Referral"
     @_setUTM()
-    @_setOptions(options)
-    @append() unless options.append is false
+    @_setOptions(mixingpanel_options.source)
+    @append() unless mixingpanel_options.source.append is false
 
   _setUTM: (qsObj = @properties.location.query_string) ->
     @utm =
@@ -71,15 +70,7 @@ class @MixingpanelSource
     allSources
 
   registerSource: ->
-    @utm.medium? or !@properties.isInternal() or @isReferringDomainException()
-
-  isReferringDomainException: () ->
-    return false unless @properties.uri.hostname?
-
-    for referringDomain in @referringDomainExceptions
-      regexp = new RegExp ".*#{referringDomain}"
-      return true if @properties.uri.hostname.match(regexp)
-    false
+    @utm.medium? or !@properties.isInternal() or @properties.isExternalDomainException()
 
   tachanSource: ->
     words = @utm.medium.split(/\s|_/)

--- a/app/assets/javascripts/mixingpanel/tracker.js.coffee
+++ b/app/assets/javascripts/mixingpanel/tracker.js.coffee
@@ -1,11 +1,24 @@
 class @MixingpanelTracker
-  constructor: (options = {internal_domain: undefined, source: {}})->
+  constructor: (options = {})->
     throw "'$' is not defined!! Ensure to call this constructor after $(document).ready" unless $?
-    @appendGlobals = if options.appendGlobals? then options.appendGlobals else true
-    @properties = new MixingpanelProperties(options.internal_domain)
-    @source = new MixingpanelSource(@properties, options.source)
-    @parameterizer = new MixingpanelParameterizer(@properties, options.tracking_params)
-    @session = new MixingpanelSession(@properties, options.source)
+
+    # General pupose options for all classes
+    window.mixingpanel_options = $.extend({}, @defaultOptions, options)
+
+    @appendGlobals = if mixingpanel_options.appendGlobals?
+      mixingpanel_options.appendGlobals
+    else
+      true
+    @properties = new MixingpanelProperties()
+    @source = new MixingpanelSource(@properties)
+    @parameterizer = new MixingpanelParameterizer(@properties)
+    @session = new MixingpanelSession(@properties)
+
+  defaultOptions:
+    internal_domain: undefined,
+    external_domains: [],
+    tracking_params: [],
+    source: {}
 
   bind: ->
     @_bindActions()


### PR DESCRIPTION
## External DOMAINS exceptions
Now, external domains excepetions list (internal domains that are considered as external) are used on SOURCE and URL_PARAMS tracking checks:

```Coffeescript
  # Enable properties/sources and bind events
  window.mixingpanel_tracker = new MixingpanelTracker
    external_domains:
      ['.land.kelisto.es',
       'comparadores.kelisto.es']
    tracking_params:
      ['partner']
    source:
      values:
        SEM_BRANDED: "SEM Branded"
        SEM_UNBRANDED: "SEM Unbranded"
        SEM_OTHERS: "SEM Others"
        DISPLAY_BRANDED: "Display Branded"
        DISPLAY_UNBRANDED: "Display Unbranded"
        DISPLAY_OTHERS: "Display Others"
        SEO_GENERIC: "SEO Generic"
        SEO_CONTENT: "SEO Content"
        SEO_BRANDED: "SEO Branded"
        SEO_OTHERS: "SEO Others"
        UNKNOWN: "Unknown Source"
      callback: ->
        if @utm.medium is "ppc"
          if @utm.content is "branded"
            @sources.SEM_BRANDED
          ...
```